### PR TITLE
[server] extendメソッドを追加

### DIFF
--- a/js/server.js
+++ b/js/server.js
@@ -39,6 +39,26 @@
       this.methods = {};
     }
 
+    StackServer.prototype.extend = function(baseServer) {
+      var method, methods, name, _ref, _ref1;
+      if (baseServer == null) {
+        return this;
+      }
+      this.pres = baseServer.pres.concat(this.pres);
+      methods = {};
+      _ref = baseServer.methods;
+      for (name in _ref) {
+        method = _ref[name];
+        methods[name] = method;
+      }
+      _ref1 = this.methods;
+      for (name in _ref1) {
+        method = _ref1[name];
+        methods[name] = method;
+      }
+      return this.methods = methods;
+    };
+
     StackServer.prototype.setupServer = function(io, options) {
       var methods, path, _ref, _results;
       this.io = io;

--- a/src/server.coffee
+++ b/src/server.coffee
@@ -26,6 +26,20 @@ class StackServer
 
     @methods = {}
 
+  extend: (baseServer) ->
+
+    return @ if not baseServer?
+
+    @pres = baseServer.pres.concat @pres
+
+    methods = {}
+
+    methods[name] = method for name, method of baseServer.methods
+
+    methods[name] = method for name, method of @methods
+
+    @methods = methods
+
   setupServer: (@io, options={}) ->
 
     @server = new Server(@io, {}, options)


### PR DESCRIPTION
あるStackServerインスタンスに対し、別インスタンスに登録されたpres, methodsを登録するextendメソッドを追加しました。(shallow copyします)

module

```
server = Server()
server.use () -> #...
module.exports = server
```

main

```
servers = {}
baseServer = require('module')
for name_space in ['project_a', 'project_b']
  server = Server()
  server.extend(baseServer)
  server.use () -> #...
  servers[name_space] = server
```
