### PR TITLE
[review] pre / post動作フィルタを追加

### DIFF
--- a/js/client.js
+++ b/js/client.js
@@ -88,7 +88,7 @@
     next = function(err, val, next) {
       return cb(err, val);
     };
-    _ref = funcs.reverse();
+    _ref = Array.prototype.concat(funcs).reverse();
     for (_i = 0, _len = _ref.length; _i < _len; _i++) {
       cur = _ref[_i];
       next = _bind(cur, next);

--- a/js/client.js
+++ b/js/client.js
@@ -1,5 +1,5 @@
 (function() {
-  var Client, Emitter, TrackClient, TrackCursor,
+  var Client, Cursor, Emitter, TrackClient, TrackCursor, buildChain,
     __hasProp = {}.hasOwnProperty,
     __extends = function(child, parent) { for (var key in parent) { if (__hasProp.call(parent, key)) child[key] = parent[key]; } function ctor() { this.constructor = child; } ctor.prototype = parent.prototype; child.prototype = new ctor(); child.__super__ = parent.prototype; return child; };
 
@@ -11,10 +11,10 @@
 
   Client = require('minimum-rpc').Client;
 
-  TrackCursor = (function(_super) {
-    __extends(TrackCursor, _super);
+  Cursor = (function(_super) {
+    __extends(Cursor, _super);
 
-    function TrackCursor(method, data, cb, client) {
+    function Cursor(method, data, cb, client) {
       this.method = method;
       this.data = data;
       this.cb = cb;
@@ -24,17 +24,17 @@
       this.mdls = [];
     }
 
-    TrackCursor.prototype.error = function(cb) {
+    Cursor.prototype.error = function(cb) {
       this.on('error', cb);
       return this;
     };
 
-    TrackCursor.prototype.end = function(cb) {
+    Cursor.prototype.end = function(cb) {
       this.on('end', cb);
       return this;
     };
 
-    TrackCursor.prototype.update = function(_data) {
+    Cursor.prototype.update = function(_data) {
       if (_data !== void 0) {
         this.data = _data;
       }
@@ -61,14 +61,93 @@
       return this;
     };
 
-    TrackCursor.prototype.map = function(mdl) {
+    Cursor.prototype.map = function(mdl) {
       this.mdls.push(mdl);
       return this;
     };
 
-    return TrackCursor;
+    return Cursor;
 
   })(Emitter);
+
+  buildChain = function(funcs, cb) {
+    var cur, err, next, val, _bind, _i, _len, _ref;
+    err = null;
+    val = void 0;
+    _bind = function(cur, next) {
+      return function(_err, _val) {
+        if (_err) {
+          err = _err;
+        }
+        if (_val) {
+          val = _val;
+        }
+        return cur(err, val, next);
+      };
+    };
+    next = function(err, val, next) {
+      return cb(err, val);
+    };
+    _ref = funcs.reverse();
+    for (_i = 0, _len = _ref.length; _i < _len; _i++) {
+      cur = _ref[_i];
+      next = _bind(cur, next);
+    }
+    return next;
+  };
+
+  TrackCursor = (function(_super) {
+    __extends(TrackCursor, _super);
+
+    function TrackCursor(method, data, cb, client) {
+      var _cb;
+      this.pres = [];
+      this.posts = [];
+      this.tracking = false;
+      _cb = (function(_this) {
+        return function(err, val) {
+          var next;
+          _this.tracking = false;
+          next = buildChain(_this.posts, cb);
+          return next(err, val);
+        };
+      })(this);
+      TrackCursor.__super__.constructor.call(this, method, data, _cb, client);
+    }
+
+    TrackCursor.prototype.pre = function(func) {
+      this.pres.push(func);
+      return this;
+    };
+
+    TrackCursor.prototype.post = function(func) {
+      this.posts.push(func);
+      return this;
+    };
+
+    TrackCursor.prototype.update = function(_data, trackContext) {
+      var next;
+      if (_data !== void 0) {
+        this.data = _data;
+      }
+      if (this.tracking) {
+        return;
+      }
+      this.tracking = true;
+      next = buildChain(this.pres, (function(_this) {
+        return function(err, trackContext) {
+          if (err) {
+            return;
+          }
+          return TrackCursor.__super__.update.call(_this, _data);
+        };
+      })(this));
+      return next(null, trackContext);
+    };
+
+    return TrackCursor;
+
+  })(Cursor);
 
   TrackClient = (function(_super) {
     __extends(TrackClient, _super);
@@ -77,13 +156,13 @@
       TrackClient.__super__.constructor.call(this, io_or_socket, options);
       this._cursors = [];
       this._socket.on(this.sub_name_space + '_track', (function(_this) {
-        return function(data) {
+        return function(trackContext) {
           var cursor, _i, _len, _ref, _results;
           _ref = _this._cursors;
           _results = [];
           for (_i = 0, _len = _ref.length; _i < _len; _i++) {
             cursor = _ref[_i];
-            _results.push(cursor.update());
+            _results.push(cursor.update(void 0, trackContext));
           }
           return _results;
         };

--- a/js/client.js
+++ b/js/client.js
@@ -127,7 +127,7 @@
 
     TrackCursor.prototype.update = function(_data, trackContext) {
       var next;
-      if (trackContext !== void 0) {
+      if (trackContext === void 0) {
         TrackCursor.__super__.update.call(this, _data);
       }
       if (this.tracking) {

--- a/js/client.js
+++ b/js/client.js
@@ -127,8 +127,8 @@
 
     TrackCursor.prototype.update = function(_data, trackContext) {
       var next;
-      if (_data !== void 0) {
-        this.data = _data;
+      if (trackContext !== void 0) {
+        TrackCursor.__super__.update.call(this, _data);
       }
       if (this.tracking) {
         return;
@@ -156,13 +156,14 @@
       TrackClient.__super__.constructor.call(this, io_or_socket, options);
       this._cursors = [];
       this._socket.on(this.sub_name_space + '_track', (function(_this) {
-        return function(trackContext) {
-          var cursor, _i, _len, _ref, _results;
+        return function(_arg) {
+          var cursor, data, _i, _len, _ref, _results;
+          data = _arg.data;
           _ref = _this._cursors;
           _results = [];
           for (_i = 0, _len = _ref.length; _i < _len; _i++) {
             cursor = _ref[_i];
-            _results.push(cursor.update(void 0, trackContext));
+            _results.push(cursor.update(void 0, data));
           }
           return _results;
         };

--- a/src/client.coffee
+++ b/src/client.coffee
@@ -55,7 +55,7 @@ buildChain = (funcs, cb) ->
       cur err, val, next
   next = (err, val, next) ->
     cb err, val
-  for cur in funcs.reverse()
+  for cur in Array.prototype.concat(funcs).reverse()
     next = _bind(cur, next)
   next
 

--- a/src/client.coffee
+++ b/src/client.coffee
@@ -83,10 +83,10 @@ class TrackCursor extends Cursor
     return @
 
   update: (_data, trackContext) ->
-    @data = _data if _data isnt undefined
+    super _data if trackContext isnt undefined
     return if @tracking
-
     @tracking = true
+
     next = buildChain @pres, (err, trackContext) =>
       return if err
       super _data
@@ -100,11 +100,11 @@ class TrackClient extends Client
 
     @_cursors = []
 
-    @_socket.on @sub_name_space + '_track', (trackContext) =>
+    @_socket.on @sub_name_space + '_track', ({data}) =>
 
       for cursor in @_cursors
 
-        cursor.update(undefined, trackContext)
+        cursor.update(undefined, data)
 
   # track api which return cursor obj.
   track: (method, data, cb) ->

--- a/src/client.coffee
+++ b/src/client.coffee
@@ -7,7 +7,7 @@ catch
 {Client} = require('minimum-rpc')
 
 # cursor class
-class TrackCursor extends Emitter
+class Cursor extends Emitter
 
   constructor: (@method, @data, @cb, @client) ->
     @val = null
@@ -45,6 +45,49 @@ class TrackCursor extends Emitter
     @mdls.push(mdl)
     return @
 
+buildChain = (funcs, cb) ->
+  err = null
+  val = undefined
+  _bind = (cur, next) ->
+    (_err, _val) ->
+      err = _err if _err
+      val = _val if _val
+      cur err, val, next
+  next = (err, val, next) ->
+    cb err, val
+  for cur in funcs.reverse()
+    next = _bind(cur, next)
+  next
+
+# cursor with track filters
+class TrackCursor extends Cursor
+
+  constructor: (method, data, cb, client) ->
+    @pres = []
+    @posts = []
+
+    _cb = (err, val) =>
+      next = buildChain(@posts, cb)
+      next err, val
+
+    super(method, data, _cb, client)
+
+  pre: (func) ->
+    @pres.push func
+    return @
+
+  post: (func) ->
+    @posts.push func
+    return @
+
+  update: (_data, trackContext) ->
+    @data = _data if _data isnt undefined
+
+    next = buildChain @pres, (err, trackContext) =>
+      return if err
+      super _data
+    next(null, trackContext)
+
 # client class
 class TrackClient extends Client
 
@@ -53,9 +96,11 @@ class TrackClient extends Client
 
     @_cursors = []
 
-    @_socket.on @sub_name_space + '_track', (data) =>
+    @_socket.on @sub_name_space + '_track', (trackContext) =>
 
-      cursor.update() for cursor in @_cursors
+      for cursor in @_cursors
+
+        cursor.update(undefined, trackContext)
 
   # track api which return cursor obj.
   track: (method, data, cb) ->

--- a/src/client.coffee
+++ b/src/client.coffee
@@ -83,7 +83,7 @@ class TrackCursor extends Cursor
     return @
 
   update: (_data, trackContext) ->
-    super _data if trackContext isnt undefined
+    super _data if trackContext is undefined
     return if @tracking
     @tracking = true
 

--- a/src/client.coffee
+++ b/src/client.coffee
@@ -65,8 +65,10 @@ class TrackCursor extends Cursor
   constructor: (method, data, cb, client) ->
     @pres = []
     @posts = []
+    @tracking = false
 
     _cb = (err, val) =>
+      @tracking = false
       next = buildChain(@posts, cb)
       next err, val
 
@@ -82,7 +84,9 @@ class TrackCursor extends Cursor
 
   update: (_data, trackContext) ->
     @data = _data if _data isnt undefined
+    return if @tracking
 
+    @tracking = true
     next = buildChain @pres, (err, trackContext) =>
       return if err
       super _data


### PR DESCRIPTION
使用例：
```
cursor = client.track 'findUsers', {}, (err, users) ->
  # ...
cursor.pre (err, trackContext, next) ->
  return next 'is not target event' if trackContext.eventName isnt 'update-pocky-user'
  next()
```