### PR TITLE
Feature/19/reject concurrent call

### DIFF
--- a/src/client.coffee
+++ b/src/client.coffee
@@ -76,10 +76,9 @@ class TrackCursor extends Cursor
   constructor: (method, data, cb, client) ->
     @pres = []
     @posts = []
-    @tracking = false
+    @tracking = true
 
     _cb = (err, val) =>
-      @tracking = false
       next = buildChain(@posts, cb)
       next err, val
 
@@ -93,10 +92,12 @@ class TrackCursor extends Cursor
     @posts.push func
     return @
 
+  track: (flag) ->
+    @tracking = flag
+
   update: (_data, trackContext) ->
     super _data if trackContext is undefined
-    return if @tracking
-    @tracking = true
+    return if @tracking is false
 
     next = buildChain @pres, (err, trackContext) =>
       return if err

--- a/src/client.coffee
+++ b/src/client.coffee
@@ -65,7 +65,7 @@ buildChain = (funcs, cb) ->
       val = _val if _val
       cur err, val, next
   next = (err, val, next) ->
-    cb err, val
+    cb err, val if cb
   for cur in Array.prototype.concat(funcs).reverse()
     next = _bind(cur, next)
   next
@@ -96,7 +96,7 @@ class TrackCursor extends Cursor
     @tracking = flag
 
   update: (_data, trackContext) ->
-    super _data if trackContext is undefined
+    return super _data if trackContext is undefined
     return if @tracking is false
 
     next = buildChain @pres, (err, trackContext) =>


### PR DESCRIPTION
refs #19 

Cursorの機能調整を行い、API問い合わせ中（完了前）に発生したupdateを保留状態に置くように変更しました。

連続して検索条件が変更になるケースでは、最後の条件変更のみが有効になります。